### PR TITLE
Fixed bug for running classifier in parallel CPU when no out_dir is specified

### DIFF
--- a/morpheus/classifier.py
+++ b/morpheus/classifier.py
@@ -130,6 +130,8 @@ class Classifier:
                 batch_size=batch_size,
             )
         else:
+            if out_dir is None:
+                out_dir = "."
             Classifier._build_parallel_classification_structure(
                 [h, j, v, z], workers, batch_size, out_dir, out_type
             )


### PR DESCRIPTION
If CPUs > 1 is specified in the classifier, it will now use the current directory as output.